### PR TITLE
feat: enhance plots and use happiness data source for fb prophet

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ $ python crystall_ball.py -f "2020/06/01" -u "2020/12/01" -d 3 -s 60 -l en_all -
 
 ## Details
 https://www.linkedin.com/pulse/future-predictions-tweets-lstm-networks-2021-crystal-ball-daboubi/
+
+http://hedonometer.org

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,17 @@
+# Author
+walid.daboubi@gmail.com
+
+#contributors
+marwen.taleb94@gmail.com
+
+# About
+Predict big events using Hedonometer.org data
+
+# Versions
+v1 2020/12/31
+
+v1.1 2021/01/01
+
+v1.2 2021/01/22 - Merging all in one entry point
+
+v1.2.1 2021/01/23 - Use plotly to enhance plots and /happiness data source endpoint for fbprophet

--- a/crystall_ball.py
+++ b/crystall_ball.py
@@ -1,51 +1,56 @@
-# Author: walid.daboubi@gmail.com
-# About: Predict big events using Hedonometer.org data
-# Version:
-    # v1 2020/12/31
-    # v1.1 2021/01/01
-    # v1.2 2021/01/22 - Merging all in one entry point
+# common imports
+from datetime import datetime, timedelta
+
+import pandas as pd
+import plotly.graph_objects as go
 
 from helpers import *
 
 ARGS = get_args()
 language = ARGS["language"] if ARGS["language"] else "en_all"
 model = ARGS["model"].lower()
-if model not in ['lstm','fbprophet']:
+if model not in ["lstm", "fbprophet"]:
     print("> The only available model options are LSTM or FBProphet")
 
-if model == 'lstm':
+if model == "lstm":
     future_depth = int(ARGS["future_depth"]) if ARGS["future_depth"] else 10
-    # Use n_steps last days to predit the current day
-    n_steps = int(ARGS['steps']) if ARGS['steps'] else 60
-    EPSILON = 10**-5
+    # Use n_steps last days to predict the current day
+    n_steps = int(ARGS["steps"]) if ARGS["steps"] else 60
+    EPSILON = 10 ** -5
     N_FEATURES = 1
     error_sum = 0
     errors, predictions, predictions_dates = [], [], []
     prediction_count = 0
     display_error = False
 
-    train_from_year, train_from_month, train_from_day = decompose_date(ARGS['train_from'])
-    train_until_year, train_until_month, train_until_day = decompose_date(ARGS['train_until'])
-    from_date_fomatted = '{}-{}-{}'.format(train_from_year, train_from_month, train_from_day)
+    train_from_year, train_from_month, train_from_day = decompose_date(
+        ARGS["train_from"]
+    )
+    train_until_year, train_until_month, train_until_day = decompose_date(
+        ARGS["train_until"]
+    )
+    from_date_fomatted = "{}-{}-{}".format(
+        train_from_year, train_from_month, train_from_day
+    )
 
     # Get data
-    data = get_time_series(language,'100000','simple',from_date_fomatted)
+    data = get_time_series(language, "100000", "simple", from_date_fomatted)
 
-    df = pd.DataFrame(data['objects'])
-    df['date'] = pd.to_datetime(df.date)
-    df.sort_values('date', inplace=True)
+    df = pd.DataFrame(data["objects"])
+    df["date"] = pd.to_datetime(df.date)
+    df.sort_values("date", inplace=True)
     df["happiness"] = df["happiness"].astype(float)
 
     train_until_date = pd.datetime(train_until_year, train_until_month, train_until_day)
-    prediction_date = train_until_date + pd.to_timedelta(1, unit = 'd')
+    prediction_date = train_until_date + pd.to_timedelta(1, unit="d")
 
     # Training data
-    training_data = df.loc[df['date'] <= train_until_date]
+    training_data = df.loc[df["date"] <= train_until_date]
     training_scores = np.array(training_data["happiness"])
     training_dates = np.array(training_data["date"])
 
     # Testing data
-    validation_data = df.loc[df['date'] > train_until_date]
+    validation_data = df.loc[df["date"] > train_until_date]
     validation_scores = np.array(validation_data["happiness"])
     validation_dates = np.array(validation_data["date"])
 
@@ -53,82 +58,107 @@ if model == 'lstm':
     from keras.models import Sequential
     from keras.layers import LSTM
     from keras.layers import Dense
+
     while prediction_count < future_depth:
-        print ('-'*50+' prediction_count = {}'.format(prediction_count))
+        print("-" * 50 + " prediction_count = {}".format(prediction_count))
         size = training_scores.shape[0]
         # Train model with training data
         X, y = split_sequence(training_scores, n_steps)
         X = X.reshape((X.shape[0], X.shape[1], N_FEATURES))
         # Define NN
         model = Sequential()
-        model.add(LSTM(20, activation = 'relu', input_shape = (n_steps, N_FEATURES)))
+        model.add(LSTM(20, activation="relu", input_shape=(n_steps, N_FEATURES)))
         model.add(Dense(1))
-        model.compile(optimizer = 'adam', loss='mse')
+        model.compile(optimizer="adam", loss="mse")
         # Fit model
         model.fit(X, y, epochs=200, verbose=0)
         # Get last n_steps point as the features of the new next point to predict
-        next_point_steps = training_scores[size-n_steps:]
+        next_point_steps = training_scores[size - n_steps :]
         x_input, none = split_sequence(next_point_steps, n_steps)
         x_input = x_input.reshape((1, n_steps, N_FEATURES))
-        yhat = model.predict(x_input, verbose = 0)[0][0]
-        print('Date: {}'.format(prediction_date))
-        print('Prediction: {}'.format(yhat))
-        if prediction_count<len(validation_scores):#.indexOf(prediction_count)>-1:
+        yhat = model.predict(x_input, verbose=0)[0][0]
+        print("Date: {}".format(prediction_date))
+        print("Prediction: {}".format(yhat))
+        if prediction_count < len(validation_scores):  # .indexOf(prediction_count)>-1:
             display_error = True
             error = abs(validation_scores[prediction_count] - yhat)
             errors.append(error)
             error_sum += error
-            print('Current Error: {}'.format(error))
-            print('Mean Error: {}'.format(error_sum/(prediction_count+EPSILON)))
+            print("Current Error: {}".format(error))
+            print("Mean Error: {}".format(error_sum / (prediction_count + EPSILON)))
             # Add the new prediction to training date
             predictions_dates.append(validation_dates[prediction_count])
-            training_dates = np.append(training_dates,validation_dates[prediction_count])
+            training_dates = np.append(
+                training_dates, validation_dates[prediction_count]
+            )
         else:
             errors.append(0)
             predictions_dates.append(np.datetime64(prediction_date))
-            training_dates = np.append(training_dates,np.datetime64(prediction_date))
-            prediction_date += pd.to_timedelta(1,unit='d')
+            training_dates = np.append(training_dates, np.datetime64(prediction_date))
+            prediction_date += pd.to_timedelta(1, unit="d")
 
         predictions.append(yhat)
-        training_scores = np.append(training_scores,yhat)
+        training_scores = np.append(training_scores, yhat)
         prediction_count += 1
 
-    # Convert arrays to np.array
-    errors = np.array(errors)
-    predictions = np.array(predictions)
-    predictions_dates = np.array(predictions_dates)
-
-    # The division by 10 goal is to be able to see error in the same chart
-    validation_scores, training_scores, predictions = validation_scores/10, training_scores/10, predictions/10
-
     # Plot
-    import matplotlib.pyplot as plt
-    plt.plot(validation_dates, validation_scores, 'b', label = 'Actual')
-    plt.plot(training_dates, training_scores, 'g', label = 'Training')
-    plt.plot(predictions_dates, predictions, 'y', label = 'Prediction')
-    if display_error == True:
-        plt.plot(predictions_dates, errors, 'r', label = 'Error')
-    plt.legend(loc = "best")
-    plt.show()
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=from_np_datetime_to_str(validation_dates),
+            y=validation_scores,
+            mode="lines",
+            line=dict(color="blue", width=2),
+            name="Actual",
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=from_np_datetime_to_str(training_dates),
+            y=training_scores,
+            line=dict(color="green", width=2),
+            mode="lines",
+            name="Training",
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=from_np_datetime_to_str(predictions_dates),
+            y=predictions,
+            line=dict(color="yellow", width=2),
+            mode="lines",
+            name="Prediction",
+        )
+    )
+    if display_error:
+        fig.add_trace(
+            go.Scatter(
+                x=from_np_datetime_to_str(predictions_dates),
+                y=errors,
+                line=dict(color="red", width=2),
+                mode="lines+markers",
+                name="Error",
+            )
+        )
+    fig.update_layout(
+        hovermode="x unified",
+        title="Training, validation, prediction and error plot using LSTM model",
+    )
+    fig.show()
 
-
-elif model == 'fbprophet':
-    import plotly.express as px
+elif model == "fbprophet":
     from fbprophet import Prophet
+
     initial_date = ARGS["train_from"].replace("/", "-")
     train_until_datetime = datetime.strptime(ARGS["train_until"], "%Y/%m/%d")
     # depth from train_until date point in days
     future_depth = int(ARGS["future_depth"]) if ARGS["future_depth"] else 365 * 2
 
-    data = get_time_series(language,'100000','events',initial_date)
+    data = get_time_series(language, "100000", "simple", initial_date)
 
     # only useful data to our study
     useful_data = [
-        {
-            "date": data_point["happs"]["date"],
-            "happiness": data_point["happs"]["happiness"],
-            "event": data_point["longer"],
-        }
+        {"date": data_point["date"], "happiness": data_point["happiness"]}
         for data_point in data["objects"]
     ]
     df_records = pd.DataFrame.from_records(useful_data)
@@ -144,16 +174,16 @@ elif model == 'fbprophet':
         & (df_records["date"] < (train_until_datetime + timedelta(days=future_depth)))
     ]
     # prepare df_train to prophet column names convention
-    df_train = df_train.drop("event", axis=1).rename(
-        columns={"date": "ds", "happiness": "y"}
-    )
+    df_train = df_train.rename(columns={"date": "ds", "happiness": "y"})
 
     # model
     # use multiplicative seasonality_mode given the non constant
     # seasonal effect observed on the dataset
     # use only weekly and yearly seasonality given our daily dataset
     prophet = Prophet(
-        seasonality_mode="multiplicative", weekly_seasonality=True, yearly_seasonality=True
+        seasonality_mode="multiplicative",
+        weekly_seasonality=True,
+        yearly_seasonality=True,
     )
     trained_model = prophet.fit(df_train)
     build_forecast = trained_model.make_future_dataframe(periods=future_depth, freq="D")
@@ -166,17 +196,8 @@ elif model == 'fbprophet':
     forecast_validation["from"] = "fbprophet"
     df_validation["from"] = "ground_truth"
     df_comparison = pd.concat([df_validation, forecast_validation]).fillna("None")
-    fig = px.line(
-        df_comparison,
-        x="date",
-        y="happiness",
-        color="from",
-        hover_name="event",
-        title="Happiness over time",
-    )
-    fig.show()
 
-    # plot error
+    # compute error indicators
     df_validation = df_validation.set_index("date").drop(["from"], axis=1)
     forecast_validation = forecast_validation.set_index("date").drop(["from"], axis=1)
     df = df_validation.join(
@@ -187,12 +208,40 @@ elif model == 'fbprophet':
     mse = round(df["square_error"].sum() / len(df) * 100, 2)
     df = df[df["happiness_predict"].notna()]
     mape = mape(df.happiness_ground_truth, df.happiness_predict)
-    fig = px.line(
-        df,
-        x=df.index,
-        y="error",
-        hover_name="event",
-        title=f"Error over time [MSE : {mse} % / MAPE : {mape} %]",
+    fig = go.Figure()
+    # ground truth
+    fig.add_trace(
+        go.Scatter(
+            x=df_comparison[df_comparison["from"] == "ground_truth"]["date"],
+            y=df_comparison[df_comparison["from"] == "ground_truth"]["happiness"],
+            mode="lines",
+            line=dict(color="green", width=2),
+            name="ground truth",
+        )
     )
-    fig.update_traces(line_color="red")
+
+    # fb prophet prediction
+    fig.add_trace(
+        go.Scatter(
+            x=df_comparison[df_comparison["from"] == "fbprophet"]["date"],
+            y=df_comparison[df_comparison["from"] == "fbprophet"]["happiness"],
+            line=dict(color="royalblue", width=2),
+            mode="lines",
+            name="fbprophet",
+        )
+    )
+    # error
+    fig.add_trace(
+        go.Scatter(
+            x=df.index,
+            y=df["error"],
+            line=dict(color="red", width=2),
+            mode="lines+markers",
+            name="Error",
+        )
+    )
+    fig.update_layout(
+        hovermode="x unified",
+        title=f"validation, prediction and error plot using FBProphet model | MAPE {mape} %| MSE {mse} %",
+    )
     fig.show()

--- a/helpers.py
+++ b/helpers.py
@@ -1,54 +1,66 @@
-# Author: walid.daboubi@gmail.com
-# About: Predict big events using Hedonometer.org data
-# Version:
-    # v1 2020/12/31
-    # v1.1 2021/01/01
-
 import argparse
-import requests
-import pandas as pd
+
 import numpy as np
-from datetime import timedelta, datetime
+import requests
+
 
 # Get user argument
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', '--train_from', help = 'Training data from date in "yyyy/mm/dd" format', required = True)
-    parser.add_argument('-u', '--train_until', help = 'Training data until date in "yyyy/mm/dd" format', required = True)
-    parser.add_argument('-d', '--future_depth', help = 'Number of days to predict', required = False)
-    parser.add_argument('-s', '--steps', help = 'Number of steps', required = False)
-    parser.add_argument('-m', '--model', help = 'Choose LSTM or FBProphet', required = True)
-    parser.add_argument('-l', '--language', help = 'Language. Available languages are ar_all, de_all, en_all, es_all, fr_all, id_all, ko_all, pt_all, ru_all ', required = False)
+    parser.add_argument(
+        "-f",
+        "--train_from",
+        help='Training data from date in "yyyy/mm/dd" format',
+        required=True,
+    )
+    parser.add_argument(
+        "-u",
+        "--train_until",
+        help='Training data until date in "yyyy/mm/dd" format',
+        required=True,
+    )
+    parser.add_argument(
+        "-d", "--future_depth", help="Number of days to predict", required=False
+    )
+    parser.add_argument("-s", "--steps", help="Number of steps", required=False)
+    parser.add_argument("-m", "--model", help="Choose LSTM or FBProphet", required=True)
+    parser.add_argument(
+        "-l",
+        "--language",
+        help="Language. Available languages are ar_all, de_all, en_all, es_all, fr_all, id_all, ko_all, pt_all, ru_all ",
+        required=False,
+    )
     return vars(parser.parse_args())
 
 
 # Get Data from "http://hedonometer.org"
-def get_time_series(language,limit,detail_level,from_date):
+def get_time_series(language, limit, detail_level, from_date):
     URI = "http://hedonometer.org/api/v1/"
-    if detail_level == 'simple':
+    if detail_level == "simple":
         URI += "happiness"
     else:
         URI += "events"
     return requests.get(
         URI,
-        params = {
-            'format': 'json',
-            'timeseries__title':language,
-            'date__gte':from_date,
-            'limit':'100000'
-        }).json()
+        params={
+            "format": "json",
+            "timeseries__title": language,
+            "date__gte": from_date,
+            "limit": "100000",
+        },
+    ).json()
 
 
 # split a univariate sequence into samples
 def split_sequence(sequence, n_steps):
     if len(sequence) == n_steps:
-        return sequence,None
+        return sequence, None
     X, y = list(), list()
     for i in range(len(sequence)):
         # find the end of this pattern
         end_ix = i + n_steps
         # check if we are beyond the sequence
-        if end_ix > len(sequence)-1:
+        if end_ix > len(sequence) - 1:
             break
         # gather input and output parts of the pattern
         seq_x, seq_y = sequence[i:end_ix], sequence[end_ix]
@@ -56,12 +68,18 @@ def split_sequence(sequence, n_steps):
         y.append(seq_y)
     return np.array(X), np.array(y)
 
+
 # Convert string dates to yyyy, mm, dd integers
 def decompose_date(str_date):
-    return [int(x) for x in str_date.split('/')]
+    return [int(x) for x in str_date.split("/")]
+
 
 # Mean Abs Percentage Error
 def mape(ground_truth, prediction):
 
-    ground_truth,prediction = np.array(ground_truth),np.array(prediction)
-    return round(np.mean((np.abs(ground_truth-prediction)/ground_truth))*100,2)
+    ground_truth, prediction = np.array(ground_truth), np.array(prediction)
+    return round(np.mean((np.abs(ground_truth - prediction) / ground_truth)) * 100, 2)
+
+
+def from_np_datetime_to_str(np_datetime_list):
+    return [str(dt) for dt in np_datetime_list]


### PR DESCRIPTION
changes : 

- use plotly to plot results of the both models
- plot training,validation,error in a unique plot for both models
- use data from /happiness endpoint for fbprophet to have more data points for training and validation and ensure same training conditions across models
- add a changelog file (we can automate its generation if we make a proper dev / release branches)
- formatting and sort imports using black and isort with default configuration
- add a clear hedonometer reference in readme